### PR TITLE
refactor(domain): restructure product, category, and review entities and repos

### DIFF
--- a/src/main/java/com/eric/ecommerce_product_service/category/entity/Category.java
+++ b/src/main/java/com/eric/ecommerce_product_service/category/entity/Category.java
@@ -1,5 +1,6 @@
-package com.eric.ecommerce_product_service.entities;
+package com.eric.ecommerce_product_service.category.entity;
 
+import com.eric.ecommerce_product_service.product.entity.Product;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/eric/ecommerce_product_service/category/repo/CategoryRepository.java
+++ b/src/main/java/com/eric/ecommerce_product_service/category/repo/CategoryRepository.java
@@ -1,6 +1,6 @@
-package com.eric.ecommerce_product_service.repositories;
+package com.eric.ecommerce_product_service.category.repo;
 
-import com.eric.ecommerce_product_service.entities.Category;
+import com.eric.ecommerce_product_service.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/eric/ecommerce_product_service/product/entity/Product.java
+++ b/src/main/java/com/eric/ecommerce_product_service/product/entity/Product.java
@@ -1,5 +1,7 @@
-package com.eric.ecommerce_product_service.entities;
+package com.eric.ecommerce_product_service.product.entity;
 
+import com.eric.ecommerce_product_service.category.entity.Category;
+import com.eric.ecommerce_product_service.review.entity.Review;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/eric/ecommerce_product_service/product/repo/ProductRepository.java
+++ b/src/main/java/com/eric/ecommerce_product_service/product/repo/ProductRepository.java
@@ -1,7 +1,7 @@
-package com.eric.ecommerce_product_service.repositories;
+package com.eric.ecommerce_product_service.product.repo;
 
-import com.eric.ecommerce_product_service.entities.Category;
-import com.eric.ecommerce_product_service.entities.Product;
+import com.eric.ecommerce_product_service.category.entity.Category;
+import com.eric.ecommerce_product_service.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/eric/ecommerce_product_service/review/entity/Review.java
+++ b/src/main/java/com/eric/ecommerce_product_service/review/entity/Review.java
@@ -1,5 +1,6 @@
-package com.eric.ecommerce_product_service.entities;
+package com.eric.ecommerce_product_service.review.entity;
 
+import com.eric.ecommerce_product_service.product.entity.Product;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/eric/ecommerce_product_service/review/repo/ReviewRepository.java
+++ b/src/main/java/com/eric/ecommerce_product_service/review/repo/ReviewRepository.java
@@ -1,6 +1,6 @@
-package com.eric.ecommerce_product_service.repositories;
+package com.eric.ecommerce_product_service.review.repo;
 
-import com.eric.ecommerce_product_service.entities.Review;
+import com.eric.ecommerce_product_service.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 


### PR DESCRIPTION

- Moved `Product`, `Category`, and `Review` entities into domain-based subpackages for better modularity
- Organized repository interfaces (`ProductRepository`, `CategoryRepository`, `ReviewRepository`) under corresponding `repo` packages